### PR TITLE
Remove Style/Encoding check

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -17,7 +17,4 @@ Style/Documentation:
 Lint/UnusedBlockArgument:
   Enabled: false
 
-Style/Encoding:
-  Enabled: true
-
 require: rubocop-rspec


### PR DESCRIPTION
As documentation say it make sense only in Ruby 1.9
see http://www.rubydoc.info/github/bbatsov/rubocop/Rubocop/Cop/Style/Encoding
