### PR TITLE
Use default rubocop settings for LineLength

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -9,9 +9,6 @@ AllCops:
     - "**/db/schema.rb"
     - 'vendor/**/*'
 
-Metrics/LineLength:
-    Max: 99
-
 Style/Documentation:
   Enabled: false
 


### PR DESCRIPTION
Its better for reviews and its part of history :heavy_exclamation_mark: