### PR TITLE
Fix Error: obsolete parameter RunRailsCops

### DIFF
--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -2,20 +2,21 @@ require 'rubocop/rake_task'
 
 desc 'Run Rubocop on the recent changes'
 RuboCop::RakeTask.new(:rubocop) do |task|
-  if (branch = `git rev-parse --abbrev-ref HEAD`) == 'master'
-    changed_files = `git diff --name-only master origin/master`.split($RS)
-  else
-    changed_files = `git diff --name-only master..#{branch}`.split($RS)
-  end
+  branch = `git rev-parse --abbrev-ref HEAD`
+  changed_files = if branch == 'master'
+                    `git diff --name-only master origin/master`.split($RS)
+                  else
+                    `git diff --name-only master..#{branch}`.split($RS)
+                  end
 
   changed_files -= %w(Gemfile Gemfile.lock)
   changed_files.select! { |f| f.ends_with? '.rb' }
 
-  if changed_files.none?
-    task.patterns = %w(*.!)
-  else
-    task.patterns = changed_files
-  end
+  task.patterns = if changed_files.none?
+                    %w(*.!)
+                  else
+                    changed_files
+                  end
 
   task.fail_on_error = false
 end

--- a/lib/td_critic/version.rb
+++ b/lib/td_critic/version.rb
@@ -1,3 +1,3 @@
 module TdCritic
-  VERSION = '0.1.0'
+  VERSION = '0.1.0'.freeze
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,5 +1,4 @@
 AllCops:
-  RunRailsCops: true
   Exclude:
     - 'bin/**/*'
     - '**/Rakefile'
@@ -8,6 +7,9 @@ AllCops:
     - 'assets/node_modules/**/*'
     - "**/db/schema.rb"
     - 'vendor/**/*'
+
+Rails:
+  Enabled: true
 
 Style/Documentation:
   Enabled: false


### PR DESCRIPTION
```
Running RuboCop...

Error: obsolete parameter RunRailsCops (for AllCops) found in /home/travis/.rvm/gems/ruby-2.2.3/gems/td_critic-0.1.0/rubocop.yml

Use the following configuration instead:

Rails:

  Enabled: true

RuboCop failed!


```