### PR TITLE
set fail_on_error to true

### DIFF
--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -18,5 +18,5 @@ RuboCop::RakeTask.new(:rubocop) do |task|
                     changed_files
                   end
 
-  task.fail_on_error = false
+  task.fail_on_error = true
 end


### PR DESCRIPTION
Usefull for git hooks. Fail hook when something is wrong.

Add
```
#!/bin/sh

bundle exec rake rubocop
```
to `.git/hooks/pre-push` or `.git/hooks/pre-commit` and make this file executable.