### PR TITLE
Disable LineLength cop for .gemspec files

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -17,4 +17,8 @@ Style/Documentation:
 Lint/UnusedBlockArgument:
   Enabled: false
 
+Metrics/LineLength:
+  Exclude:
+    - '**/*.gemspec'
+
 require: rubocop-rspec


### PR DESCRIPTION
Gemspec files often include descriptions and summaries that are longer than the 80 char limit.
And it seems unnecessary and ugly to change the the file to fit these limits. 