### PR TITLE
Force rubocop 0.35 for rubocop-rspec issue

### DIFF
--- a/td_critic.gemspec
+++ b/td_critic.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = []
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.35'
+  spec.add_dependency 'rubocop', '= 0.35'
   spec.add_dependency 'rubocop-rspec', '~> 1.3'
 
   spec.add_development_dependency 'bundler', '~> 1.10'


### PR DESCRIPTION
see https://github.com/nevir/rubocop-rspec/pull/60
Merged but no release yet.