### PR TITLE
Remove Rails cop; let enable per project

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -8,9 +8,6 @@ AllCops:
     - "**/db/schema.rb"
     - 'vendor/**/*'
 
-Rails:
-  Enabled: true
-
 Style/Documentation:
   Enabled: false
 


### PR DESCRIPTION
We maintaining gems also and this is not usefull.