### PR TITLE
Skip vendor node modules in any directories

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
     - '**/Rakefile'
     - 'Gemfile.lock'
     - 'db/schema.rb'
-    - 'assets/node_modules/**/*'
+    - 'node_modules/**/*'
     - "**/db/schema.rb"
     - 'vendor/**/*'
 


### PR DESCRIPTION
This node modules are vendor libraries we don't want to check.
I also had `Warning: Deprecated pattern style` that trigger my attention to that.

Currently path are still checked:

```
assets/node_modules/jquery-ujs/test/server.rb
```