### PR TITLE
Ignore rubocop 0.39

### DIFF
--- a/td_critic.gemspec
+++ b/td_critic.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = []
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.37', '!= 0.38'
+  spec.add_dependency 'rubocop', '~> 0.37', '!= 0.38', '!= 0.39'
   spec.add_dependency 'rubocop-rspec', '~> 1.4'
 
   spec.add_development_dependency 'bundler', '~> 1.10'


### PR DESCRIPTION
rubocop 0.39 release breaks rubocop-rspec and there is so far no fix
released for making it compatible.

Ref:
- https://github.com/nevir/rubocop-rspec/issues/78
- https://github.com/nevir/rubocop-rspec/pull/79