### PR TITLE
Lock rubocop and rubocop-rspec versions

### DIFF
--- a/td_critic.gemspec
+++ b/td_critic.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = []
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.37', '!= 0.38', '!= 0.39'
-  spec.add_dependency 'rubocop-rspec', '~> 1.4'
+  spec.add_dependency 'rubocop', '0.37.2'
+  spec.add_dependency 'rubocop-rspec', '1.4.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
- rubocop 0.37.2
- rubocop-rspec 1.4.0

rubocop 0.38 and 0.39 releases break rubocop-rspec and there is so far
no fix released for making it compatible.

Ref:
- https://github.com/nevir/rubocop-rspec/issues/78
- https://github.com/nevir/rubocop-rspec/pull/79