### PR TITLE
Line length max 100

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -14,4 +14,7 @@ Style/Documentation:
 Lint/UnusedBlockArgument:
   Enabled: false
 
+LineLength:
+  Max: 100
+
 require: rubocop-rspec


### PR DESCRIPTION
Would you consider line length 100 to avoid. This will prevent things like:

    --- a/config/application.rb
    +++ b/config/application.rb
    @@ -8,16 +8,21 @@ Bundler.require(*Rails.groups)
    
    module Pulse
      class Application < Rails::Application
        -    # Settings in config/environments/* take precedence over those specified here.
        +    # Settings in config/environments/* take precedence over those specified
        +    # here.
        # Application configuration should go into files in config/initializers
        # -- all .rb files in that directory are automatically loaded.
    
        -    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
        -    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
        +    # Set Time.zone default to the specified zone and make Active Record
        +    # auto-convert to this zone.
        +    # Run "rake -D time" for a list of tasks for finding time zone names.
        +    # Default is UTC.
        # config.time_zone = 'Central Time (US & Canada)'
    
        -    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
        -    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
        +    # The default locale is :en and all translations from
        +    # config/locales/*.rb,yml are auto loaded.
        +    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales',
        +    # '*.{rb,yml}').to_s]
    # config.i18n.default_locale = :de