### PR TITLE
Revert lock on rubocop and rubocop-rspec

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+Unreleased
+===================
+
+  * Revert lock on `rubocop` and `rubocop-rspec`, bugs preventing us from using
+    them were fixed
+
 v0.4.0 / 2016-03-30
 ===================
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -14,4 +14,7 @@ Style/Documentation:
 Lint/UnusedBlockArgument:
   Enabled: false
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 require: rubocop-rspec

--- a/td_critic.gemspec
+++ b/td_critic.gemspec
@@ -9,10 +9,10 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Dash Boys']
   spec.email         = ['developer@td-berlin.com']
 
-  spec.summary       = 'TD Critic is a gem that specializes in judging' \
-    ' your coding style.'
-  spec.description   = 'TD Critic uses rubocop to check your code based' \
-    ' on the Ruby Style Guide.'
+  spec.summary       = 'TD Critic is a gem that specializes in judging ' \
+                       'your coding style.'
+  spec.description   = 'TD Critic uses rubocop to check your code based ' \
+                       'on the Ruby Style Guide.'
   spec.homepage      = 'https://www.github.com/td-berlin/td_critic'
   spec.license       = 'MIT'
 
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = []
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '0.37.2'
-  spec.add_dependency 'rubocop-rspec', '1.4.0'
+  spec.add_dependency 'rubocop', '~> 0.41.2'
+  spec.add_dependency 'rubocop-rspec', '~> 1.5.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Revert lock on `rubocop` and `rubocop-rspec`, bugs preventing us from using them were fixed.