### PR TITLE
Set default delimeter for percent literals to `()`

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+v0.7.0 / 2017-06-26
+===================
+
+  * Set preferred delimeters for percent literals to `()`
+
 v0.6.0 / 2017-06-20
 ===================
 

--- a/lib/td_critic/version.rb
+++ b/lib/td_critic/version.rb
@@ -1,3 +1,3 @@
 module TdCritic
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.7.0'.freeze
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -17,4 +17,12 @@ Lint/UnusedBlockArgument:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Style/PercentLiteralDelimeters:
+  PreferredDelimiters:
+    default: '()'
+    '%i': '()'
+    '%I': '()'
+    '%w': '()'
+    '%W': '()'
+
 require: rubocop-rspec


### PR DESCRIPTION
Since rubocop changed the default delimiter for percent literals in [0.48.1](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0481-2017-04-03), it might cause a lot of warnings in our existing projects. This PR reverts to `()` delimiter for percent literals.

I don't have permission to push this gem to `rubygems.td-asp.com`. So the owner should either run `bundle exec rake release` after merging this PR, or add me as owner: `gem owner td_critic --add lebedev.yurii@gmail.com`.