### PR TITLE
Allow projects to select preferred version of rubocop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v0.7.0 / 2018-08-15
+===================
+
+  * Allow projects to select preferred version of rubocop
+
 v0.6.0 / 2017-06-20
 ===================
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ Add this to your application's Gemfile:
 gem 'td_critic'
 ```
 
+If you want to make sure that your project's build won't be broken accidentally by `rubocop` update, lock `rubocop` to certain version:
+
+```ruby
+gem 'rubocop', '0.58.2'
+gem 'rubocop-rspec', '1.28.0'
+```
+
+That is important especially for GEMs, where `Gemfile.lock` isn't committed to the repository.
+
 ## Usage
 
 Add the following line to your rubocop config

--- a/td_critic.gemspec
+++ b/td_critic.gemspec
@@ -1,6 +1,4 @@
-# coding: utf-8
-
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'td_critic/version'
 
@@ -21,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = []
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.49.1'
-  spec.add_dependency 'rubocop-rspec', '~> 1.15.1'
+  spec.add_dependency 'rubocop', '>= 0.49.1'
+  spec.add_dependency 'rubocop-rspec', '>= 1.15.1'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 12.0'


### PR DESCRIPTION
Right now `td_critic` is locking `rubocop` and `rubocop-rspec` to certain version.

We should let projects using `td_critic` to select preferred versions, so the updates of `rubocop` does not require updating `td_critic` all the time.

Added appropriate entry to the `README`.

Also renamed `History.md` to `CHANGELOG.md` to match td standards.